### PR TITLE
Update good advice message when kernelcare is installed and up to date

### DIFF
--- a/pkg/Cpanel/Security/Advisor/Assessors/Kernel.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Kernel.pm
@@ -394,7 +394,7 @@ sub _check_kernelcare_kernel {
         $self->add_good_advice(
             'key'  => 'Kernel_kernelcare_is_current',
             'text' => $self->_lh->maketext(
-                'The system kernel is up-to-date at version “[_1]”.',
+                'KernelCare is installed and current running kernel version is up to date: [_1]',
                 $kernel->{running_version},
             ),
         );

--- a/t/pkg-Cpanel-Security-Advisor-Assessors-Kernel.t
+++ b/t/pkg-Cpanel-Security-Advisor-Assessors-Kernel.t
@@ -47,6 +47,8 @@ plan tests => 4;
 my $envtype = Test::MockModule->new('Cpanel::KernelCare');
 $envtype->mock( system_supports_kernelcare => sub { 0 } );    # Disable KernelCare advertisements.
 
+local $ENV{'REQUEST_URI'} = 'mocking out to avoid warnings';
+
 subtest 'Error parsing boot configuration' => sub {
     plan tests => 2;
 
@@ -244,7 +246,7 @@ subtest 'KernelCare systems' => sub {
         function => ignore(),
         advice   => {
             key  => 'Kernel_kernelcare_is_current',
-            text => 'The system kernel is up-to-date at version “3.10.0-514.el7.x86_64”.',
+            text => 'KernelCare is installed and current running kernel version is up to date: 3.10.0-514.el7.x86_64',
             type => $Cpanel::Security::Advisor::ADVISE_GOOD,
         },
     };
@@ -308,7 +310,7 @@ subtest 'KernelCare systems' => sub {
         function => ignore(),
         advice   => {
             key  => 'Kernel_kernelcare_is_current',
-            text => 'The system kernel is up-to-date at version “3.10.0-514.el7.x86_64”.',
+            text => 'KernelCare is installed and current running kernel version is up to date: 3.10.0-514.el7.x86_64',
             type => $Cpanel::Security::Advisor::ADVISE_GOOD,
         },
     };
@@ -395,7 +397,7 @@ subtest 'KernelCare systems' => sub {
         function => ignore(),
         advice   => {
             key  => 'Kernel_kernelcare_is_current',
-            text => 'The system kernel is up-to-date at version “3.10.0-514.2.2.el7.x86_64”.',
+            text => 'KernelCare is installed and current running kernel version is up to date: 3.10.0-514.2.2.el7.x86_64',
             type => $Cpanel::Security::Advisor::ADVISE_GOOD,
         },
     };
@@ -472,7 +474,7 @@ subtest 'KernelCare systems' => sub {
         function => ignore(),
         advice   => {
             key  => 'Kernel_kernelcare_is_current',
-            text => 'The system kernel is up-to-date at version “3.10.0-514.10.2.el7.x86_64”.',
+            text => 'KernelCare is installed and current running kernel version is up to date: 3.10.0-514.10.2.el7.x86_64',
             type => $Cpanel::Security::Advisor::ADVISE_GOOD,
         },
     };


### PR DESCRIPTION
Case BOO-668: Update the good advice message to mention kernelcare when
kernelcare is installed and up to date.

Changelog: Update good advice message when kernelcare is installed and up to
    date